### PR TITLE
Fix the field name for getting the work item id in the context menu.

### DIFF
--- a/Views/Static/ShareExtension.cshtml
+++ b/Views/Static/ShareExtension.cshtml
@@ -10,7 +10,7 @@
                 execute: function (actionContext) {
                     var webContext = VSS.getWebContext();
                     
-                    open('http://vso.io/share?account=' + webContext.account.name + '&id=' + actionContext.workItemId, '_blank', 'height=120,width=400');
+                    open('http://vso.io/share?account=' + webContext.account.name + '&id=' + actionContext.workItemIds[0], '_blank', 'height=120,width=400');
                 }
             };
         }());


### PR DESCRIPTION
I don't know if it is because of different versions of VSO but without this change the id was always undefined for me.
