### PR TITLE
Change the extension to only display the icon (no text) on the toolbar

### DIFF
--- a/Views/Static/ShareExtension.cshtml
+++ b/Views/Static/ShareExtension.cshtml
@@ -9,13 +9,14 @@
             return {
                 execute: function (actionContext) {
                     var webContext = VSS.getWebContext();
+                    var wiId = actionContext.workItemId !== undefined ? actionContext.workItemId : actionContext.workItemIds[0];
                     
-                    open('http://vso.io/share?account=' + webContext.account.name + '&id=' + actionContext.workItemIds[0], '_blank', 'height=120,width=400');
+                    open('http://vso.io/share?account=' + webContext.account.name + '&id=' + wiId, '_blank', 'height=120,width=400');
                 }
             };
         }());
 
-        VSS.register("copyShortLinkMenu", actionContributionHandler);
+        VSS.register("copyShortLink", actionContributionHandler);
 
     </script>
 

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -22,14 +22,30 @@
             "type": "ms.vss-web.action",
             "description": "",
             "targets": [
-                "ms.vss-work-web.work-item-context-menu"
+                "ms.vss-work-web.backlog-item-menu"
             ],
             "properties": {
                 "text": "Copy short link",
                 "title": "Copy short link for this work item",
                 "icon": "content/extension-action.png",
                 "group": "actions",
-                "uri": "/extension/share"
+                "uri": "/extension/share",
+                "registeredObjectId": "copyShortLink"
+            }
+        },
+        {
+            "id": "copyShortLinkToolbar",
+            "type": "ms.vss-web.action",
+            "description": "",
+            "targets": [
+                "ms.vss-work-web.work-item-toolbar-menu"
+            ],
+            "properties": {
+                "title": "Copy short link for this work item",
+                "icon": "content/extension-action.png",
+                "group": "actions",
+                "uri": "/extension/share",
+                "registeredObjectId": "copyShortLink"
             }
         }
     ]


### PR DESCRIPTION
Added another contribution to the manifest to have different appearance in the menus (on right click) and on the toolbar (viewing the item full screen). By adding just another target to the existing contribution I could not achieve that (if you know how to do that then please correct me). 

I also had to change the target of the existing contribution (no it applies only to backlog items menu) to avoid having two buttons (one with the text) on the toolbar. This also means that the menu option does not appear when right clicking in the query results list. There it would be necessary to have yet another way of retrieving the id of the work item to make it work.

We wanted to have just the icon on the toolbar. Feel free to skip this one if you prefer it the other way.
